### PR TITLE
Fix: Credentials invalid on local runner

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Test execution
       run: |
-        pytest --env=test --mode=pipeline --headless --alluredir=allure-results -n=auto --reruns=2 --reruns-delay=3 --screenshot=on
+        pytest --mode=pipeline --headless --alluredir=allure-results -n=auto --reruns=2 --reruns-delay=3 --screenshot=on
 
     - name: Load test report history
       uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ reports
 .auth/
 tests/reports
 tests/resume_builder_feature/smoke/data/
+/data/credentials.json

--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,6 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    os.environ["env"] = config.getoption('env')
     os.environ["mode"] = config.getoption('mode') or 'local'
     os.environ["headless"] = str(config.getoption('headless'))
     os.environ["screenshot"] = config.getoption('screenshot')

--- a/pages/login/__init__.py
+++ b/pages/login/__init__.py
@@ -21,4 +21,4 @@ class PreCond(BasePage):
             await self._type(Interactor.username_input, os.getenv("USERNAME_COMMON"))
             await self._type(Interactor.password_input, os.getenv("PASSWORD_COMMON"))
             await self._click(Interactor.login_btn)
-            assert 'secure' in self.page.url
+            assert 'secure' in self.page.url, f"Login failed, incorrect URL: {self.page.url}"

--- a/utils/browser_config.py
+++ b/utils/browser_config.py
@@ -20,9 +20,7 @@ class Config:
             "headless": headless,
             "args": ["--start-maximized"]}
 
-        if mode == 'pipeline':
-            self.browser = await playwright[browser_type].launch(**launch_args)
-        elif mode == 'local':
+        if mode in ['pipeline', 'local']:
             self.browser = await playwright[browser_type].launch(**launch_args)
         elif mode == 'grid':
             server_url = "http://remote-playwright-server:4444"


### PR DESCRIPTION
# What's New:

## `workflows`
- Remove `--env` parser

## `.gitignore`
- Add `credential.json` exclusion on the repository 

## `conftest.py`
- Remove `--env` parser

## `login_init`
- Add proper message on the invalid setup


## `browser_config.py`
- Shorten the browser mode into array/list